### PR TITLE
feat(build): Generate MD and txt application artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The site should stay simple, semantic, accessible, and easy to revisit after lon
 - CSS is bundled with Lightning CSS from `src/styles/main.css`.
 - Pico CSS provides a lightweight base layer; local CSS should own the site's specific visual language.
 - Public assets live in `public/` and are copied into `dist/`.
-- PDF output is generated with WeasyPrint for HTML pages configured with `pdf: true`.
+- PDF output is generated with WeasyPrint for HTML pages whose `formats` include `pdf`.
 - Generated output in `dist/` should not be treated as source.
 
 Current source organization:
@@ -44,10 +44,10 @@ Current source organization:
 
 Configured routes:
 
-- `config.yaml` controls generated routes through its `pages` list. Supported page keys are `home`, `resume`, and `privacy`; omit an entry to exclude its HTML page. Set `pdf: true` on an HTML page entry to generate a PDF with the same basename.
+- `config.yaml` controls generated routes through its `pages` list. Supported page keys are `home`, `resume`, and `privacy`; omit an entry to exclude its HTML page. `formats` may contain `html`, `pdf`, `md`, and `txt`, defaults to HTML, must be nonempty/unique, and include HTML. The legacy `pdf` field is rejected.
 - `/index.html` from `src/pages/Home.tsx` when the `home` page is configured.
 - `/resume.html` from `src/pages/Resume.tsx` when the `resume` page is configured.
-- `/resume.pdf` from `dist/resume.html` when the resume page has `pdf: true`.
+- `/resume.pdf`, `/resume.md`, and `/resume.txt` from `dist/resume.html` when configured.
 - `/privacy.html` from `src/pages/Privacy.tsx` when the `privacy` page is configured.
 - `/sitemap.xml` from the configured routes' canonical URLs.
 
@@ -75,12 +75,13 @@ When changing content shape, update the matching schema in `src/content/schemas/
 ## Development Commands
 
 - `npm run dev` starts the rebuild/watch and local static server.
-- `npm run build` builds HTML, CSS, public assets, the sitemap, and any configured PDFs. It accepts `--configFile`, repeated `--contentDir`, `--outputDir`, repeated `--page`, and `--analytics` or `--no-analytics`; outputs must be `dist/` or beneath it.
+- `npm run build` builds HTML, CSS, public assets, the sitemap, and configured document formats. It accepts `--configFile`, repeated `--contentDir`, `--outputDir`, repeated `--page`, and `--analytics` or `--no-analytics`; outputs must be `dist/` or beneath it.
 - `npm run build:resume -- <lowercase-slug>` is a private resume preset. It infers `content/` and `variants/<slug>/`, accepts additional ordered `--contentDir` layers, disables analytics by default, and writes to `variants/output/<slug>/` unless an override beneath `variants/output/` is supplied.
+- `npm run build:application -- <lowercase-slug>` builds private resume and optional cover-letter packages. Each present document emits HTML, PDF, Markdown, and text artifacts; analytics, sitemap, canonical/social metadata, and JSON-LD are omitted and output is noindex.
 - `npm run check` runs typecheck, lint, formatting, and tests.
 - `npm run format` applies Prettier.
 
-When any page has `pdf: true`, local builds require WeasyPrint from `requirements.txt`. A project virtual environment keeps that dependency isolated:
+When any page includes `pdf` in `formats`, local builds require WeasyPrint from `requirements.txt`. A project virtual environment keeps that dependency isolated:
 
 ```sh
 python3 -m venv .venv
@@ -164,6 +165,6 @@ Before finishing meaningful changes:
 - Run `npm run build` when changes affect rendering, CSS, assets, or build behavior.
 - Review generated HTML when changing document structure, metadata, navigation, or accessibility-sensitive markup.
 - For visual changes, sanity-check desktop and mobile layouts when feasible.
-- For resume or print changes, review both `dist/resume.html` and `dist/resume.pdf` when feasible.
+- For resume or print changes, review `dist/resume.html`, `dist/resume.pdf`, `dist/resume.md`, and `dist/resume.txt` when feasible.
 
 Keep final notes concise: describe what changed, what was verified, and any known follow-up.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PATH="$PWD/.venv/bin:$PATH" npm run dev
 ```
 
 Build the site. The TypeScript build script renders HTML, bundles CSS, copies public
-assets, writes the sitemap, and generates PDFs for pages configured with `pdf: true`:
+assets, writes the sitemap, and generates the configured document formats:
 
 ```sh
 PATH="$PWD/.venv/bin:$PATH" npm run build
@@ -56,12 +56,18 @@ PATH="$PWD/.venv/bin:$PATH" npm run build
 
 Build a private role-specific resume variant (for example, the ignored UMBC adjunct
 variant). The preset infers the shared baseline and variant directory, builds only the
-resume with analytics disabled, and writes its local submission PDF to
-`variants/output/<variant>/resume.pdf`:
+resume with analytics disabled, and writes HTML, PDF, Markdown, and text artifacts to
+`variants/output/<variant>/`:
 
 ```sh
 PATH="$PWD/.venv/bin:$PATH" npm run build:resume -- umbc-adjunct \
   --contentDir variants/content-sensitive
+```
+
+Build a private application package with an optional cover letter. When present, it writes `resume.html/pdf/md/txt` and `cover-letter.html/pdf/md/txt` under `variants/output/<variant>/`; it omits analytics, sitemap, canonical/social metadata, and adds `noindex`.
+
+```sh
+PATH="$PWD/.venv/bin:$PATH" npm run build:application -- umbc-adjunct
 ```
 
 Run the maintenance checks:
@@ -97,8 +103,8 @@ Private resume patches belong under ignored `variants/`, where they can override
 
 ## Architecture
 
-- `src/build/build.tsx` resolves the public-build or resume-preset command options, while `src/build/buildSite.tsx` provides their shared pipeline: it cleans the selected safe output directory, loads configuration and resolved Markdown layers, copies public assets, bundles CSS, renders React pages to static HTML, generates configured PDFs, and writes a sitemap.
-- `config.yaml` controls generated pages through its `pages` list. Add `pdf: true` to an HTML page entry to generate a PDF alongside it; for example, `/resume.html` produces `/resume.pdf`.
+- `src/build/build.tsx` resolves the public-build or resume-preset command options, while `src/build/buildSite.tsx` provides their shared pipeline: it cleans the selected safe output directory, loads configuration and resolved Markdown layers, copies public assets, bundles CSS, renders static HTML, generates configured PDF/Markdown/text artifacts, and writes a sitemap.
+- `config.yaml` controls generated pages through its `pages` list. Use a `formats` array; resume may emit `html`, `pdf`, `md`, and `txt` siblings.
 - `src/styles/main.css` is bundled and minified by Lightning CSS.
 - `src/pages/` contains page-level composition for the homepage and resume.
 - `src/components/` contains reusable page, profile, hero, link, site, and resume components.
@@ -111,7 +117,7 @@ GitHub Pages deployment is handled by `.github/workflows/pages.yml` on pushes to
 
 ## Troubleshooting
 
-If a configured page has `pdf: true`, the build requires WeasyPrint. If `weasyprint`
+If a configured page includes `pdf` in `formats`, the build requires WeasyPrint. If `weasyprint`
 is not found locally, make sure the virtual environment is installed and prepended to
 `PATH` when building:
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ pages:
       Resume for Chris Thierer, a Baltimore/DC software engineering leader with
       experience across public-sector technology, web platforms, and video game live
       services.
-    pdf: true
+    formats: [html, pdf, md, txt]
 
   - key: privacy
     title: 'Privacy | Chris Thierer'

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -26,7 +26,7 @@ Common updates:
 - Education: `content/education/*.md`.
 - Email, website, and social links: `content/contact/*.md` and `content/social/*.md`.
 - Organization names, display labels, locations, and optional logos: `content/organizations/*.md`.
-- Site URL, favicon, social image, resume download path, and generated pages: `config.yaml`. Pages are configured in the `pages` list. Each entry has a supported `key` (`home`, `resume`, or `privacy`), `title`, `description`, and output `path`; `canonicalPath` is optional and defaults to `path`. Omit a page entry to exclude its HTML page. Set `pdf: true` on an HTML page entry to generate a PDF with the same basename, such as `dist/resume.pdf` from `/resume.html`.
+- Site URL, favicon, social image, resume download path, and generated pages: `config.yaml`. Pages use a `formats` array of `html`, `pdf`, `md`, and `txt`; it defaults to HTML, must be nonempty/unique, and include HTML. Resume Markdown/text are direct serializations of resolved content, not HTML conversions. The application cover letter emits all four formats when present.
 
 ## Frontmatter Quick Reference
 
@@ -84,8 +84,7 @@ Build an application package (resume plus an optional cover letter) with:
 PATH="$PWD/.venv/bin:$PATH" npm run build:application -- umbc-adjunct
 ```
 
-This writes `resume.html`, `resume.pdf`, and, when present, `cover-letter.html` and
-`cover-letter.pdf` under `variants/output/umbc-adjunct/`. Application documents are
+This writes `resume.html`, `resume.pdf`, `resume.md`, and `resume.txt`, plus (when present) `cover-letter.html`, `cover-letter.pdf`, `cover-letter.md`, and `cover-letter.txt` under `variants/output/umbc-adjunct/`: eight document artifacts when the cover letter exists. Application documents are
 private: analytics, sitemap, canonical/social metadata, and JSON-LD are omitted and
 they include `noindex, nofollow`. Use `--page resume` or `--page cover-letter` to
 narrow the build; explicitly requesting a missing cover letter fails.
@@ -131,7 +130,7 @@ PATH="$PWD/.venv/bin:$PATH" npm run build:resume -- umbc-adjunct \
   --contentDir variants/umbc-adjunct
 ```
 
-That command resolves the layers as `content/`, `variants/content-sensitive/`, and `variants/umbc-adjunct/`. If `content/` or `variants/<variant>/` is already specified, the preset does not add it twice; every other supplied layer retains its order. Without `--outputDir`, it writes local HTML, assets, sitemap, and the submission PDF to `variants/output/<variant>/`; the PDF is `variants/output/<variant>/resume.pdf`. A supplied `--outputDir` must remain below `variants/output/`. Analytics are disabled by default, but `--analytics` explicitly enables them.
+That command resolves the layers as `content/`, `variants/content-sensitive/`, and `variants/umbc-adjunct/`. Without `--outputDir`, it writes resume HTML, PDF, Markdown, and text artifacts to `variants/output/<variant>/`. `build:resume` disables analytics by default but otherwise retains normal metadata and sitemap behavior; `build:application` is the noindex/private package mode. A supplied `--outputDir` must remain below `variants/output/`.
 
 The relative Markdown path is the overlay identity. For example, `variants/umbc-adjunct/resume/Skills.md` patches `content/resume/Skills.md`; if a baseline file is renamed, rename every matching patch. A patch can provide only changed frontmatter fields. Plain objects merge recursively, arrays and scalar values replace inherited values, and `null` removes an inherited field. A blank patch body inherits baseline Markdown; a nonblank body replaces it. Set `published: false` to suppress an inherited entry entirely.
 
@@ -140,7 +139,7 @@ To add a variant:
 1. Create `variants/<lowercase-slug>/` and add only the files that differ from the baseline.
 2. Add sensitive links, such as a phone number, under `variants/content-sensitive/` when they are appropriate for more than one private variant, and pass that directory with `--contentDir`.
 3. Add a full `resume-section` file for a new section, choosing an unused order.
-4. Build it with `npm run build:resume -- <lowercase-slug>` and inspect its HTML and PDF before submitting.
+4. Build it with `npm run build:resume -- <lowercase-slug>` and inspect its HTML, PDF, Markdown, and text artifacts before submitting.
 
 ## Link Placement
 
@@ -173,11 +172,11 @@ selected output directory, then:
 2. Copies `public/` into the selected output directory.
 3. Bundles and minifies `src/styles/main.css` into the selected output directory's `assets/` folder.
 4. Renders each configured page to HTML.
-5. Generates a PDF for each page configured with `pdf: true`.
+5. Generates each configured sibling format; `pdf` uses WeasyPrint and resume `md`/`txt` are direct document serializations.
 6. Writes the sitemap from the configured routes.
 
 PDF generation uses WeasyPrint and therefore requires the project virtual environment
-on `PATH` locally. Pages without `pdf: true` do not produce a PDF.
+on `PATH` locally. Pages whose formats omit `pdf` do not produce a PDF.
 
 The reusable build pipeline is in `src/build/buildSite.tsx`. Both commands use the same resolved options and cleanup lifecycle. Public `npm run build` defaults to `config.yaml`, `content/`, `dist/`, all configured pages, and analytics enabled; its explicit `--contentDir` values become the complete ordered layer list. `build:resume` is only a convenience preset over those same options. Cleanup accepts only `dist/` or its descendants for public builds, and strict descendants of `variants/output/` for resume builds; for example, `npm run build -- --outputDir dist/application`. It also rejects output paths that overlap source, configuration, or selected content, as well as symlinked paths.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@picocss/pico": "^2.1.1",
+				"entities": "^8.0.0",
 				"lucide-react": "^1.24.0",
 				"react": "^19.2.7",
 				"react-dom": "^19.2.7",
@@ -1992,6 +1993,18 @@
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
 		},
 		"node_modules/environment": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	},
 	"dependencies": {
 		"@picocss/pico": "^2.1.1",
+		"entities": "^8.0.0",
 		"lucide-react": "^1.24.0",
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",

--- a/src/build/Route.ts
+++ b/src/build/Route.ts
@@ -1,14 +1,14 @@
 import { StructuredDataContext } from '../layouts/Page'
 import { JsonLdValue } from '../metadata/JsonLd'
-
-type Formats = 'pdf' | 'html'
+import type { DocumentFormat } from '../config/Config'
 
 interface Route {
+	readonly key: 'home' | 'resume' | 'privacy' | 'cover-letter'
 	readonly outputPath: string
 	readonly canonicalPath: string
 	readonly title: string
 	readonly description: string
-	readonly formats: Formats[]
+	readonly formats: readonly DocumentFormat[]
 	readonly element: React.ReactElement
 	readonly structuredData?: (context: StructuredDataContext) => JsonLdValue
 }

--- a/src/build/buildSite.test.ts
+++ b/src/build/buildSite.test.ts
@@ -98,7 +98,13 @@ require('node:fs').writeFileSync(process.argv.at(-1), 'test PDF')
 	)
 	await fs.chmod(fakeWeasyPrint, 0o755)
 	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
-	await fs.writeFile(configFile, testConfig)
+	await fs.writeFile(
+		configFile,
+		testConfig.replace(
+			'description: Test resume',
+			'description: Test resume\n    formats: [html, pdf, md, txt]',
+		),
+	)
 
 	await buildSite({
 		analyticsEnabled: false,
@@ -121,5 +127,190 @@ require('node:fs').writeFileSync(process.argv.at(-1), 'test PDF')
 	assert.match(html, /noindex, nofollow/)
 	assert.doesNotMatch(html, /rel="canonical"|property="og:|name="twitter:|cloud\.umami\.is/)
 	assert.equal(await fs.readFile(path.join(outputDir, 'cover-letter.pdf'), 'utf8'), 'test PDF')
+	for (const extension of ['md', 'txt'] as const) {
+		const artifact = await fs.readFile(path.join(outputDir, `cover-letter.${extension}`), 'utf8')
+		assert.ok(artifact.endsWith('\n'))
+		assert.doesNotMatch(artifact, /\r/)
+	}
+	await assert.rejects(fs.access(path.join(outputDir, 'sitemap.xml')), /ENOENT/)
+})
+
+test('configured public resume emits four document formats while preserving public metadata', async t => {
+	const cwd = process.cwd()
+	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.format-build-'))
+	const bin = await fs.mkdtemp(path.join('/tmp', 'format-bin-'))
+	const outputDir = path.join(root, 'output')
+	const originalPath = process.env.PATH
+	t.after(async () => {
+		process.env.PATH = originalPath
+		await Promise.all([
+			fs.rm(root, { recursive: true, force: true }),
+			fs.rm(bin, { recursive: true, force: true }),
+		])
+	})
+	await fs.writeFile(
+		path.join(bin, 'weasyprint'),
+		`#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.argv.at(-1), 'PDF')`,
+	)
+	await fs.chmod(path.join(bin, 'weasyprint'), 0o755)
+	process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ''}`
+	const configFile = path.join(root, 'config.yaml')
+	await fs.writeFile(
+		configFile,
+		testConfig.replace(
+			'description: Test resume',
+			'description: Test resume\n    formats: [html, pdf, md, txt]',
+		),
+	)
+	await buildSite({ configFile, contentDirs: [path.join(cwd, 'content')], cwd, outputDir })
+	for (const extension of ['html', 'pdf', 'md', 'txt'])
+		await fs.access(path.join(outputDir, `resume.${extension}`))
+	assert.match(await fs.readFile(path.join(outputDir, 'resume.html'), 'utf8'), /cloud\.umami\.is/)
+	assert.match(await fs.readFile(path.join(outputDir, 'resume.html'), 'utf8'), /resume-download/)
+	assert.match(await fs.readFile(path.join(outputDir, 'resume.md'), 'utf8'), /^# Chris Thierer/m)
+	assert.match(await fs.readFile(path.join(outputDir, 'resume.txt'), 'utf8'), /^Chris Thierer/m)
+	await fs.access(path.join(outputDir, 'sitemap.xml'))
+})
+
+test('resume document formats follow the configured HTML sibling path', async t => {
+	const cwd = process.cwd()
+	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.cv-path-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	const outputDir = path.join(root, 'output')
+	const configFile = path.join(root, 'config.yaml')
+	await fs.writeFile(
+		configFile,
+		testConfig
+			.replace('/resume.html', '/cv.html')
+			.replace(
+				'description: Test resume',
+				'description: Test resume\n    formats: [html, md, txt]',
+			),
+	)
+	await buildSite({
+		configFile,
+		contentDirs: [path.join(cwd, 'content')],
+		cwd,
+		outputDir,
+		pageKeys: ['resume'],
+	})
+	for (const name of ['cv.html', 'cv.md', 'cv.txt']) await fs.access(path.join(outputDir, name))
+	for (const name of ['resume.md', 'resume.txt'])
+		await assert.rejects(fs.access(path.join(outputDir, name)), /ENOENT/)
+	assert.doesNotMatch(await fs.readFile(path.join(outputDir, 'cv.html'), 'utf8'), /resume-download/)
+})
+
+test('external resume downloads remain available without a configured PDF sibling', async t => {
+	const cwd = process.cwd()
+	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.external-resume-download-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	const outputDir = path.join(root, 'output')
+	const configFile = path.join(root, 'config.yaml')
+	await fs.writeFile(
+		configFile,
+		testConfig
+			.replace(
+				'resumeDownload: /resume.pdf',
+				'resumeDownload: https://files.example.test/resume.pdf',
+			)
+			.replace('description: Test resume', 'description: Test resume\n    formats: [html]'),
+	)
+	await buildSite({
+		configFile,
+		contentDirs: [path.join(cwd, 'content')],
+		cwd,
+		outputDir,
+		pageKeys: ['resume'],
+	})
+	assert.match(
+		await fs.readFile(path.join(outputDir, 'resume.html'), 'utf8'),
+		/href="https:\/\/files\.example\.test\/resume\.pdf"[^>]*data-umami-event="resume-download"/,
+	)
+})
+
+test('application cover letter remains optional unless explicitly required', async t => {
+	const cwd = process.cwd()
+	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.optional-letter-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	const outputDir = path.join(root, 'output')
+	const options = {
+		analyticsEnabled: false,
+		configFile: path.join(root, 'config.yaml'),
+		contentDirs: [path.join(cwd, 'content')],
+		coverLetterEnabled: true,
+		cwd,
+		outputDir,
+		pageKeys: ['cover-letter'],
+		privateDocument: true,
+	} as const
+	await fs.writeFile(options.configFile, testConfig)
+	await buildSite(options)
+	await assert.rejects(fs.access(path.join(outputDir, 'cover-letter.html')), /ENOENT/)
+	await assert.rejects(
+		buildSite({ ...options, coverLetterRequired: true }),
+		/cover letter was requested/,
+	)
+})
+
+test('application package emits all eight private resume and cover-letter documents', async t => {
+	const cwd = process.cwd()
+	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.application-package-'))
+	const contentDir = await fs.mkdtemp(path.join('/tmp', 'application-package-content-'))
+	const bin = await fs.mkdtemp(path.join('/tmp', 'application-package-bin-'))
+	const outputDir = path.join(root, 'output')
+	const originalPath = process.env.PATH
+	t.after(async () => {
+		process.env.PATH = originalPath
+		await Promise.all([
+			fs.rm(root, { recursive: true, force: true }),
+			fs.rm(contentDir, { recursive: true, force: true }),
+			fs.rm(bin, { recursive: true, force: true }),
+		])
+	})
+	await fs.mkdir(path.join(contentDir, 'cover-letter'))
+	await fs.writeFile(
+		path.join(contentDir, 'cover-letter', 'letter.md'),
+		`---\ntitle: Letter\narchetype: cover-letter\npublished: true\ndate: 2026-08-12\nrecipient:\n  organization: Example\ngreeting: Hello,\n---\n\nLetter **body**.`,
+	)
+	await fs.writeFile(
+		path.join(bin, 'weasyprint'),
+		`#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.argv.at(-1), 'PDF')`,
+	)
+	await fs.chmod(path.join(bin, 'weasyprint'), 0o755)
+	process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ''}`
+	const configFile = path.join(root, 'config.yaml')
+	await fs.writeFile(
+		configFile,
+		testConfig.replace(
+			'description: Test resume',
+			'description: Test resume\n    formats: [html, pdf, md, txt]',
+		),
+	)
+	await buildSite({
+		analyticsEnabled: false,
+		configFile,
+		contentDirs: [path.join(cwd, 'content'), contentDir],
+		coverLetterEnabled: true,
+		coverLetterRequired: true,
+		cwd,
+		outputDir,
+		pageKeys: ['resume', 'cover-letter'],
+		privateDocument: true,
+	})
+	for (const name of [
+		'resume.html',
+		'resume.pdf',
+		'resume.md',
+		'resume.txt',
+		'cover-letter.html',
+		'cover-letter.pdf',
+		'cover-letter.md',
+		'cover-letter.txt',
+	])
+		await fs.access(path.join(outputDir, name))
+	const html = await fs.readFile(path.join(outputDir, 'resume.html'), 'utf8')
+	assert.doesNotMatch(html, /cloud\.umami\.is|rel="canonical"|property="og:/)
+	assert.match(await fs.readFile(path.join(outputDir, 'resume.md'), 'utf8'), /## Profile/)
+	assert.match(await fs.readFile(path.join(outputDir, 'cover-letter.txt'), 'utf8'), /Letter body/)
 	await assert.rejects(fs.access(path.join(outputDir, 'sitemap.xml')), /ENOENT/)
 })

--- a/src/build/buildSite.test.ts
+++ b/src/build/buildSite.test.ts
@@ -98,13 +98,7 @@ require('node:fs').writeFileSync(process.argv.at(-1), 'test PDF')
 	)
 	await fs.chmod(fakeWeasyPrint, 0o755)
 	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
-	await fs.writeFile(
-		configFile,
-		testConfig.replace(
-			'description: Test resume',
-			'description: Test resume\n    formats: [html, pdf, md, txt]',
-		),
-	)
+	await fs.writeFile(configFile, testConfig)
 
 	await buildSite({
 		analyticsEnabled: false,
@@ -254,7 +248,7 @@ test('application cover letter remains optional unless explicitly required', asy
 
 test('application package emits all eight private resume and cover-letter documents', async t => {
 	const cwd = process.cwd()
-	const root = await fs.mkdtemp(path.join(cwd, 'dist', '.application-package-'))
+	const root = await fs.mkdtemp(path.join(cwd, 'variants', 'output', '.application-package-'))
 	const contentDir = await fs.mkdtemp(path.join('/tmp', 'application-package-content-'))
 	const bin = await fs.mkdtemp(path.join('/tmp', 'application-package-bin-'))
 	const outputDir = path.join(root, 'output')
@@ -279,13 +273,7 @@ test('application package emits all eight private resume and cover-letter docume
 	await fs.chmod(path.join(bin, 'weasyprint'), 0o755)
 	process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ''}`
 	const configFile = path.join(root, 'config.yaml')
-	await fs.writeFile(
-		configFile,
-		testConfig.replace(
-			'description: Test resume',
-			'description: Test resume\n    formats: [html, pdf, md, txt]',
-		),
-	)
+	await fs.writeFile(configFile, testConfig)
 	await buildSite({
 		analyticsEnabled: false,
 		configFile,
@@ -294,6 +282,7 @@ test('application package emits all eight private resume and cover-letter docume
 		coverLetterRequired: true,
 		cwd,
 		outputDir,
+		outputMode: 'application',
 		pageKeys: ['resume', 'cover-letter'],
 		privateDocument: true,
 	})
@@ -310,6 +299,7 @@ test('application package emits all eight private resume and cover-letter docume
 		await fs.access(path.join(outputDir, name))
 	const html = await fs.readFile(path.join(outputDir, 'resume.html'), 'utf8')
 	assert.doesNotMatch(html, /cloud\.umami\.is|rel="canonical"|property="og:/)
+	assert.match(html, /href="\/resume\.pdf"[^>]*data-umami-event="resume-download"/)
 	assert.match(await fs.readFile(path.join(outputDir, 'resume.md'), 'utf8'), /## Profile/)
 	assert.match(await fs.readFile(path.join(outputDir, 'cover-letter.txt'), 'utf8'), /Letter body/)
 	await assert.rejects(fs.access(path.join(outputDir, 'sitemap.xml')), /ENOENT/)

--- a/src/build/buildSite.tsx
+++ b/src/build/buildSite.tsx
@@ -21,6 +21,15 @@ import writePage from './writePage'
 import writePDF from './writePDF'
 import writeSitemap from './writeSitemap'
 import { schema as configSchema } from '../config/Config'
+import {
+	createCoverLetterDocument,
+	createResumeDocument,
+	serializeCoverLetterText,
+	serializeResumeText,
+	serializeCoverLetterMarkdown,
+	serializeResumeMarkdown,
+} from '../content/documents'
+import { writeTextDocument } from './writeTextDocument'
 
 export interface BuildSiteOptions {
 	/** Enables third-party analytics in rendered HTML. Defaults to the public-site behavior. */
@@ -77,12 +86,13 @@ const selectPages = (
 
 const createRoutes = (config: Config, content: Entry[]): readonly Route[] =>
 	config.pages.map(
-		({ key, title, path: outputPath, canonicalPath = outputPath, description, pdf }) => ({
+		({ key, title, path: outputPath, canonicalPath = outputPath, description, formats }) => ({
+			key,
 			outputPath,
 			canonicalPath,
 			title,
 			description,
-			formats: ['html' as const, ...(pdf ? ['pdf' as const] : [])],
+			formats,
 			element: getElementForKey(key),
 			structuredData:
 				key === 'home'
@@ -127,16 +137,21 @@ export const buildSite = async ({
 				throw new Error('A cover letter was requested but no published cover letter was found.')
 		} else {
 			routes.push({
+				key: 'cover-letter',
 				outputPath: '/cover-letter.html',
 				canonicalPath: '/cover-letter.html',
 				title: String(coverLetter.data.title),
 				description: 'Cover letter',
-				formats: ['html', 'pdf'],
+				formats: ['html', 'pdf', 'md', 'txt'],
 				element: getElementForKey('cover-letter'),
 			})
 		}
 	}
 	for (const route of routes) {
+		const resumeDocument =
+			route.key === 'resume' ? createResumeDocument(content, config) : undefined
+		const coverLetterDocument =
+			route.key === 'cover-letter' ? createCoverLetterDocument(content, config) : undefined
 		await writePage(
 			outputDir,
 			route.outputPath,
@@ -159,6 +174,22 @@ export const buildSite = async ({
 		if (route.formats.includes('pdf')) {
 			await writePDF(cwd, outputDir, route.outputPath)
 		}
+		const markdown = resumeDocument
+			? serializeResumeMarkdown(resumeDocument)
+			: coverLetterDocument
+				? serializeCoverLetterMarkdown(coverLetterDocument)
+				: undefined
+		if (markdown && route.formats.includes('md'))
+			await writeTextDocument(outputDir, route.outputPath, 'md', markdown)
+		if (markdown && route.formats.includes('txt'))
+			await writeTextDocument(
+				outputDir,
+				route.outputPath,
+				'txt',
+				resumeDocument
+					? serializeResumeText(resumeDocument)
+					: serializeCoverLetterText(coverLetterDocument!),
+			)
 	}
 
 	if (!privateDocument)

--- a/src/build/buildSite.tsx
+++ b/src/build/buildSite.tsx
@@ -84,6 +84,15 @@ const selectPages = (
 	return { ...config, pages }
 }
 
+const applicationResumeFormats: Config['pages'][number]['formats'] = ['html', 'pdf', 'md', 'txt']
+
+const forceApplicationResumeFormats = (config: Config): Config => ({
+	...config,
+	pages: config.pages.map(page =>
+		page.key === 'resume' ? { ...page, formats: [...applicationResumeFormats] } : page,
+	),
+})
+
 const createRoutes = (config: Config, content: Entry[]): readonly Route[] =>
 	config.pages.map(
 		({ key, title, path: outputPath, canonicalPath = outputPath, description, formats }) => ({
@@ -124,7 +133,13 @@ export const buildSite = async ({
 		contentDirs.map(contentDir => loadMarkdown(contentDir, path.relative(cwd, contentDir) || '.')),
 	)
 	const content = await resolveMarkdownLayers(contentLayers)
-	const config = selectPages(await loadYaml(configFile, configSchema), pageKeys, coverLetterEnabled)
+	const selectedConfig = selectPages(
+		await loadYaml(configFile, configSchema),
+		pageKeys,
+		coverLetterEnabled,
+	)
+	const config =
+		outputMode === 'application' ? forceApplicationResumeFormats(selectedConfig) : selectedConfig
 
 	await copyPublic(path.join(cwd, 'public'), outputDir)
 	await buildCSS(path.join(cwd, 'src'), outputDir)

--- a/src/build/loadYaml.ts
+++ b/src/build/loadYaml.ts
@@ -10,11 +10,11 @@ const formatPath = (path: PropertyKey[]): string => {
 	return path.join('.')
 }
 
-const validate = <T>(fileName: string, data: unknown, schema: z.ZodType<T>): data is T => {
+const validate = <T>(fileName: string, data: unknown, schema: z.ZodType<T>): T => {
 	const result = schema.safeParse(data)
 
 	if (result.success) {
-		return true
+		return result.data
 	}
 
 	const issues = result.error.issues
@@ -28,11 +28,7 @@ const loadYaml = async <T>(fileName: string, schema: z.ZodType<T>): Promise<T> =
 	const file = await fs.readFile(fileName, { encoding: 'utf8' })
 	const { data } = matter(`---\n${file}\n---\n`)
 
-	if (!validate(fileName, data, schema)) {
-		throw new Error(`Invalid YAML in ${fileName}`)
-	}
-
-	return data
+	return validate(fileName, data, schema)
 }
 
 export default loadYaml

--- a/src/build/writeTextDocument.test.ts
+++ b/src/build/writeTextDocument.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import { writeTextDocument } from './writeTextDocument'
+
+test('text siblings require HTML paths and use LF with one final newline', async t => {
+	const root = await fs.mkdtemp(path.join('/tmp', 'text-document-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	await writeTextDocument(root, '/nested/resume.html', 'md', 'one\r\ntwo\n\n')
+	assert.equal(await fs.readFile(path.join(root, 'nested', 'resume.md'), 'utf8'), 'one\ntwo\n')
+	await assert.rejects(
+		writeTextDocument(root, '/nested/resume.pdf', 'txt', 'no'),
+		/must be an HTML path/,
+	)
+})

--- a/src/build/writeTextDocument.ts
+++ b/src/build/writeTextDocument.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const siblingPath = (htmlPath: string, extension: 'md' | 'txt'): string => {
+	if (path.extname(htmlPath) !== '.html') {
+		throw new Error(
+			`cannot write ${extension} sibling for ${htmlPath}: source must be an HTML path`,
+		)
+	}
+	return htmlPath.slice(0, -'.html'.length) + `.${extension}`
+}
+
+export const writeTextDocument = async (
+	outputDir: string,
+	htmlPath: string,
+	extension: 'md' | 'txt',
+	contents: string,
+): Promise<void> => {
+	const outputPath = path.join(outputDir, siblingPath(htmlPath, extension))
+	await fs.mkdir(path.dirname(outputPath), { recursive: true })
+	await fs.writeFile(
+		outputPath,
+		`${contents.replace(/\r\n?/g, '\n').replace(/\n*$/, '')}\n`,
+		'utf8',
+	)
+}

--- a/src/components/document/DocumentActions.tsx
+++ b/src/components/document/DocumentActions.tsx
@@ -1,5 +1,5 @@
 interface DocumentActionsProps {
-	readonly download: string
+	readonly download?: string
 	readonly label: string
 	readonly backHref?: string
 	readonly eventPrefix?: string
@@ -9,14 +9,16 @@ const DocumentActions = ({ download, label, backHref, eventPrefix }: DocumentAct
 	<nav className="document-actions container" aria-label={`${label} actions`}>
 		{backHref ? <a href={backHref}>Back</a> : null}
 		<div className="document-action-links">
-			<a
-				href={download}
-				download
-				type="application/pdf"
-				data-umami-event={eventPrefix ? `${eventPrefix}-download` : undefined}
-			>
-				PDF
-			</a>
+			{download ? (
+				<a
+					href={download}
+					download
+					type="application/pdf"
+					data-umami-event={eventPrefix ? `${eventPrefix}-download` : undefined}
+				>
+					PDF
+				</a>
+			) : null}
 			<button
 				type="button"
 				data-print-document

--- a/src/components/resume/ResumeActions.tsx
+++ b/src/components/resume/ResumeActions.tsx
@@ -4,9 +4,12 @@ import DocumentActions from '../document/DocumentActions'
 const ResumeActions = () => {
 	const resumeDownload = useConfigValue('resumeDownload')
 	const homePage = usePage('home')
+	const resumePage = usePage('resume')
+	const isExternal = /^https?:\/\//.test(resumeDownload)
+	const download = isExternal || resumePage?.formats?.includes('pdf') ? resumeDownload : undefined
 	return (
 		<DocumentActions
-			download={resumeDownload}
+			download={download}
 			label="Resume"
 			backHref={homePage?.path}
 			eventPrefix="resume"

--- a/src/components/resume/ResumeEducationSection.tsx
+++ b/src/components/resume/ResumeEducationSection.tsx
@@ -1,11 +1,15 @@
-import { useResumeEducation } from '../../content/resume'
+import type EducationEntry from '../../content/EducationEntry'
 import { YearText } from '../DateText'
 import { formatEducationLabel } from './format'
 import ResumeSection from './ResumeSection'
 
-const ResumeEducationSection = ({ title }: { readonly title: string }) => {
-	const education = useResumeEducation()
-
+const ResumeEducationSection = ({
+	title,
+	education,
+}: {
+	readonly title: string
+	readonly education: readonly EducationEntry[]
+}) => {
 	return (
 		<ResumeSection id="resume-education" title={title}>
 			<div className="resume-education-list">

--- a/src/components/resume/ResumeExperienceSection.tsx
+++ b/src/components/resume/ResumeExperienceSection.tsx
@@ -1,4 +1,4 @@
-import { useResumeExperience } from '../../content/resume'
+import type { ResumeRole } from '../../content/documents'
 import ExperienceEntry from '../../content/ExperienceEntry'
 import DateRangeText from '../DateText'
 import ResumeSection from './ResumeSection'
@@ -7,13 +7,11 @@ const hasResumeContent = (experience: ExperienceEntry): boolean =>
 	Boolean(experience.resumeSummary || experience.resumeHighlights.length > 0)
 
 interface ResumeExperienceSectionProps {
-	readonly limit?: number
+	readonly roles: readonly ResumeRole[]
 	readonly title: string
 }
 
-const ResumeExperienceSection = ({ limit, title }: ResumeExperienceSectionProps) => {
-	const roles = useResumeExperience(limit)
-
+const ResumeExperienceSection = ({ roles, title }: ResumeExperienceSectionProps) => {
 	return (
 		<ResumeSection id="resume-experience" title={title}>
 			<div className="resume-timeline">

--- a/src/components/resume/ResumeHeader.tsx
+++ b/src/components/resume/ResumeHeader.tsx
@@ -1,9 +1,8 @@
-import { useResumeLinks, useResumeProfile } from '../../content/resume'
+import type { ResumeDocument } from '../../content/documents'
 import { formatResumeLinkLabel } from './format'
 
-const ResumeHeader = () => {
-	const profile = useResumeProfile()
-	const links = useResumeLinks()
+const ResumeHeader = ({ document }: { readonly document: ResumeDocument }) => {
+	const { profile, links } = document
 
 	return (
 		<header className="resume-header">

--- a/src/components/resume/ResumeSections.tsx
+++ b/src/components/resume/ResumeSections.tsx
@@ -1,8 +1,8 @@
 import {
 	type ResumeProseSection,
 	type ResumeSection as ResumeSectionData,
-	useResumeSections,
 } from '../../content/resume'
+import type { ResumeDocument } from '../../content/documents'
 import ResumeEducationSection from './ResumeEducationSection'
 import ResumeExperienceSection from './ResumeExperienceSection'
 import ResumeMetrics from './ResumeMetrics'
@@ -22,8 +22,8 @@ const ResumeProse = ({ section }: { readonly section: ResumeProseSection }) => (
 	</ResumeSection>
 )
 
-const ResumeSections = () => {
-	const sections = useResumeSections()
+const ResumeSections = ({ document }: { readonly document: ResumeDocument }) => {
+	const sections = document.sections
 
 	return sections.map(section => {
 		switch (section.kind) {
@@ -39,12 +39,18 @@ const ResumeSections = () => {
 				return (
 					<ResumeExperienceSection
 						key={section.entryName}
-						limit={section.limit}
+						roles={section.roles}
 						title={section.title}
 					/>
 				)
 			case 'education':
-				return <ResumeEducationSection key={section.entryName} title={section.title} />
+				return (
+					<ResumeEducationSection
+						key={section.entryName}
+						education={section.education}
+						title={section.title}
+					/>
+				)
 		}
 	})
 }

--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { schema } from './Config'
+
+const base = {
+	siteUrl: 'https://example.test',
+	siteTitle: 'Test',
+	favIcon: 'favicon.svg',
+	profileImage: '/profile.webp',
+	socialImage: '/social.png',
+	resumeDownload: '/resume.pdf',
+}
+const page = { key: 'resume', title: 'Resume', path: '/resume.html', description: 'Test' }
+
+test('page formats default to HTML and validate document-output constraints', () => {
+	assert.deepEqual(schema.parse({ ...base, pages: [page] }).pages[0]?.formats, ['html'])
+	assert.deepEqual(
+		schema.parse({ ...base, pages: [{ ...page, formats: ['html', 'pdf', 'md', 'txt'] }] }).pages[0]
+			?.formats,
+		['html', 'pdf', 'md', 'txt'],
+	)
+	for (const formats of [[], ['pdf'], ['html', 'html']] as const)
+		assert.throws(() => schema.parse({ ...base, pages: [{ ...page, formats }] }))
+	assert.throws(
+		() => schema.parse({ ...base, pages: [{ ...page, pdf: true }] }),
+		/legacy pdf field/,
+	)
+	assert.throws(
+		() => schema.parse({ ...base, pages: [{ ...page, key: 'home', formats: ['html', 'txt'] }] }),
+		/only for the resume/,
+	)
+})

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -3,14 +3,38 @@ import path from 'node:path'
 
 const absolutePath = (val: string) => path.isAbsolute(val)
 
-const pageSchema = z.looseObject({
-	key: z.enum(['home', 'resume', 'privacy']),
-	title: z.string(),
-	path: z.string().refine(absolutePath),
-	canonicalPath: z.string().refine(absolutePath).optional(),
-	description: z.string(),
-	pdf: z.boolean().optional(),
-})
+export const documentFormatSchema = z.enum(['html', 'pdf', 'md', 'txt'])
+export type DocumentFormat = z.infer<typeof documentFormatSchema>
+
+const pageSchema = z
+	.looseObject({
+		key: z.enum(['home', 'resume', 'privacy']),
+		title: z.string(),
+		path: z.string().refine(absolutePath),
+		canonicalPath: z.string().refine(absolutePath).optional(),
+		description: z.string(),
+		formats: z
+			.array(documentFormatSchema)
+			.nonempty('Page formats must not be empty.')
+			.refine(values => new Set(values).size === values.length, 'Page formats must be unique.')
+			.refine(values => values.includes('html'), 'Page formats must include html.')
+			.default(['html']),
+		pdf: z
+			.never({ error: 'The legacy pdf field is no longer supported; use formats: [html, pdf].' })
+			.optional(),
+	})
+	.superRefine((page, context) => {
+		if (
+			page.key !== 'resume' &&
+			page.formats?.some(format => format === 'md' || format === 'txt')
+		) {
+			context.addIssue({
+				code: 'custom',
+				message: 'Markdown and text formats are supported only for the resume page.',
+				path: ['formats'],
+			})
+		}
+	})
 
 export const schema = z.looseObject({
 	siteUrl: z.httpUrl(),

--- a/src/content/coverLetter.ts
+++ b/src/content/coverLetter.ts
@@ -16,6 +16,7 @@ export interface CoverLetter {
 	readonly subject?: string
 	readonly closing: string
 	readonly html: string
+	readonly markdown: string
 }
 
 export const getCoverLetter = (content: ReturnType<typeof useContent>): CoverLetter | undefined => {
@@ -31,7 +32,12 @@ export const getCoverLetter = (content: ReturnType<typeof useContent>): CoverLet
 		throw new Error(`Published cover letter must have a Markdown body: ${entry.name}`)
 	}
 	const data = entry.data as CoverLetter & Record<string, unknown>
-	return { ...data, closing: data.closing ?? 'Sincerely,', html: entry.html }
+	return {
+		...data,
+		closing: data.closing ?? 'Sincerely,',
+		html: entry.html,
+		markdown: entry.markdown,
+	}
 }
 
 export const useCoverLetter = (): CoverLetter | undefined => getCoverLetter(useContent())

--- a/src/content/documents.test.ts
+++ b/src/content/documents.test.ts
@@ -106,6 +106,12 @@ test('text serializer exactly preserves visible contact and link conventions', (
 	)
 	assert.equal(serializeText('- parent\n  - child\n- sibling'), '- parent\n  - child\n- sibling')
 	assert.equal(serializeText('- one\n  - two\n    - three'), '- one\n  - two\n    - three')
+	assert.equal(
+		serializeText(
+			'3. third\n   - child\n     7. seventh\n        - deep\n     8. eighth\n   - sibling\n4. fourth',
+		),
+		'3. third\n  - child\n    7. seventh\n      - deep\n    8. eighth\n  - sibling\n4. fourth',
+	)
 })
 
 test('resume Markdown and text serializers have an exact all-section golden', () => {

--- a/src/content/documents.test.ts
+++ b/src/content/documents.test.ts
@@ -1,0 +1,399 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import type Config from '../config/Config'
+import { resolveMarkdownLayers } from '../build/contentLayers'
+import loadMarkdown from '../build/loadMarkdown'
+import {
+	createCoverLetterDocument,
+	createResumeDocument,
+	type CoverLetterDocument,
+	type ResumeDocument,
+	serializeCoverLetterMarkdown,
+	serializeCoverLetterText,
+	serializeResumeMarkdown,
+	serializeResumeText,
+	serializeText,
+} from './documents'
+
+const cwd = process.cwd()
+const config: Config = {
+	siteUrl: 'https://example.test',
+	siteTitle: 'Test Site',
+	favIcon: 'favicon.svg',
+	profileImage: '/profile.webp',
+	socialImage: '/social.png',
+	resumeDownload: '/resume.pdf',
+	pages: [],
+}
+const content = async () =>
+	resolveMarkdownLayers([await loadMarkdown(path.join(cwd, 'content'), 'content')])
+
+test('resume document resolves ordered sections, contacts, roles, education, and canonical markdown', async () => {
+	const document = createResumeDocument(await content(), config)
+	assert.equal(document.profile.name, 'Chris Thierer')
+	assert.deepEqual(
+		document.links.map(link => link.href),
+		['mailto:hello@christhierer.com', 'https://www.christhierer.com'],
+	)
+	assert.deepEqual(
+		document.sections.map(section => section.kind),
+		['metrics', 'profile', 'skills', 'experience', 'education'],
+	)
+	const experience = document.sections.find(section => section.kind === 'experience')
+	assert.ok(experience && experience.roles.length > 0)
+	const education = document.sections.find(section => section.kind === 'education')
+	assert.ok(education && education.education.length > 0)
+	const markdown = serializeResumeMarkdown(document)
+	assert.match(markdown, /^# Chris Thierer/m)
+	assert.match(markdown, /^## Experience/m)
+	assert.match(markdown, /^### Engineering Manager II/m)
+	assert.match(markdown, /\[hello@christhierer\.com\]\(mailto:hello@christhierer\.com\)/)
+	assert.match(markdown, /- \*\*15 years — Experience\*\*/)
+})
+
+test('serializers preserve Markdown tokens, normalize ASCII text, and reject unsupported text characters', () => {
+	assert.equal(
+		serializeText('A **bold** [link](https://example.test)\n\n- one\n- two'),
+		'A bold link (https://example.test)\n\n- one\n- two',
+	)
+	assert.equal(serializeText('“Café”—it’s fine…'), '"Cafe"-it\'s fine...')
+	assert.throws(() => serializeText('emoji 😀'), /ASCII-normalized/)
+})
+
+test('text serializer exactly preserves visible contact and link conventions', () => {
+	assert.equal(
+		serializeText(
+			'[person@example.test](mailto:person@example.test) [Phone](tel:555) [Baltimore](geo:1,2) [Site](https://example.test)\n\n- one\n- two\n\nInline `code` and [normal](https://normal.test).\n\n```\nblock\n```',
+		),
+		'person@example.test Phone Baltimore Site (https://example.test)\n\n- one\n- two\n\nInline code and normal (https://normal.test).\n\nblock',
+	)
+	assert.equal(serializeText('- parent\n  - child\n- sibling'), '- parent\n  - child\n- sibling')
+	assert.equal(serializeText('- one\n  - two\n    - three'), '- one\n  - two\n    - three')
+})
+
+test('resume Markdown and text serializers have an exact all-section golden', () => {
+	const role = (data: Record<string, unknown>, markdown = '') => ({
+		data,
+		markdown,
+		get jobTitle() {
+			return this.data.jobTitle as string
+		},
+		get startDate() {
+			return new Date(this.data.startDate as string)
+		},
+		get endDate() {
+			return this.data.endDate ? new Date(this.data.endDate as string) : undefined
+		},
+		get location() {
+			return this.data.location as string
+		},
+		get resumeSummary() {
+			return this.data.resumeSummary as string | undefined
+		},
+		get resumeHighlights() {
+			return (this.data.resumeHighlights as string[] | undefined) ?? []
+		},
+	})
+	const document = {
+		profile: {
+			entryName: 'profile',
+			html: '',
+			markdown: 'Profile *body*.',
+			order: 20,
+			title: 'About',
+			kind: 'profile',
+			name: 'Ada',
+			headline: 'Leader',
+			location: 'Baltimore',
+		},
+		links: [
+			{
+				href: 'mailto:ada@example.test',
+				label: 'Email',
+				name: 'email',
+				order: 1,
+				slug: 'email',
+				title: 'Email',
+				category: 'contact',
+			},
+			{
+				href: 'tel:555',
+				label: 'Phone',
+				name: 'phone',
+				order: 2,
+				slug: 'phone',
+				title: 'Phone',
+				category: 'contact',
+			},
+			{
+				href: 'geo:1,2',
+				label: 'Baltimore',
+				name: 'geo',
+				order: 3,
+				slug: 'geo',
+				title: 'Baltimore',
+				category: 'contact',
+			},
+			{
+				href: 'https://example.test',
+				label: 'Site',
+				name: 'site',
+				order: 4,
+				slug: 'site',
+				title: 'Site',
+				category: 'contact',
+			},
+		],
+		sections: [
+			{
+				entryName: 'metrics',
+				html: '',
+				markdown: '',
+				order: 10,
+				title: 'Numbers',
+				kind: 'metrics',
+				metrics: [{ value: '10', label: 'Years', detail: 'Delivery' }],
+			},
+			{
+				entryName: 'profile',
+				html: '',
+				markdown: 'Profile *body*.',
+				order: 20,
+				title: 'About',
+				kind: 'profile',
+				name: 'Ada',
+				headline: 'Leader',
+				location: 'Baltimore',
+			},
+			{
+				entryName: 'skills',
+				html: '',
+				markdown: '',
+				order: 30,
+				title: 'Skills',
+				kind: 'skills',
+				groups: [{ label: 'Code', items: ['TypeScript', 'Go'] }],
+			},
+			{
+				entryName: 'prose',
+				html: '',
+				markdown: 'See [guide](https://guide.test) and `code`.\n\n- one\n- two',
+				order: 40,
+				title: 'Notes',
+				kind: 'prose',
+			},
+			{
+				entryName: 'experience',
+				html: '',
+				markdown: '',
+				order: 50,
+				title: 'Work',
+				kind: 'experience',
+				roles: [
+					{
+						experience: role({
+							jobTitle: 'Manager',
+							startDate: '2020-01-01',
+							location: 'Remote',
+							resumeSummary: 'Led.',
+							resumeHighlights: ['Shipped.'],
+						}),
+						organization: { label: 'Org' },
+					},
+					{
+						experience: role(
+							{
+								jobTitle: 'Engineer',
+								startDate: '2019-01-01',
+								endDate: '2020-01-01',
+								location: 'Here',
+							},
+							'Fallback [link](https://fallback.test).',
+						),
+						organization: { label: 'Old' },
+					},
+				],
+			},
+			{
+				entryName: 'education',
+				html: '',
+				markdown: '',
+				order: 60,
+				title: 'School',
+				kind: 'education',
+				education: [
+					{
+						degree: 'B.S.',
+						program: 'CS',
+						institution: 'University',
+						endDate: new Date('2018-01-01'),
+						honors: ['Honors'],
+					},
+				],
+			},
+		],
+	} as unknown as ResumeDocument
+	const expected = `# Ada\n\nLeader | Baltimore\n\n[ada@example.test](mailto:ada@example.test)\n[Phone](tel:555)\n[Baltimore](geo:1,2)\n[example.test](https://example.test)\n\n## Numbers\n\n- **10 — Years**: Delivery\n\n## About\n\nProfile *body*.\n\n## Skills\n\n- **Code:** TypeScript, Go\n\n## Notes\n\nSee [guide](https://guide.test) and \`code\`.\n\n- one\n- two\n\n## Work\n\n### Manager\n\nOrg | Jan 2020 - Present | Remote\n\nLed.\n\n- Shipped.\n### Engineer\n\nOld | Jan 2019 - Jan 2020 | Here\n\nFallback [link](https://fallback.test).\n\n## School\n\n### B.S., CS\n\nUniversity | 2018\n\n- Honors\n`
+	assert.equal(serializeResumeMarkdown(document), expected)
+	assert.equal(
+		serializeResumeText(document),
+		`Ada\n\nLeader | Baltimore\n\nada@example.test\nPhone\nBaltimore\nexample.test (https://example.test)\n\nNumbers\n\n- 10 - Years: Delivery\n\nAbout\n\nProfile body.\n\nSkills\n\n- Code: TypeScript, Go\n\nNotes\n\nSee guide (https://guide.test) and code.\n\n- one\n- two\n\nWork\n\nManager\n\nOrg | Jan 2020 - Present | Remote\n\nLed.\n\n- Shipped.\n\nEngineer\n\nOld | Jan 2019 - Jan 2020 | Here\n\nFallback link (https://fallback.test).\n\nSchool\n\nB.S., CS\n\nUniversity | 2018\n\n- Honors`,
+	)
+})
+
+test('cover letter Markdown and text serializers have an exact full golden', () => {
+	const document = {
+		profile: { name: 'Ada', headline: 'Leader', location: 'Baltimore' },
+		senderName: 'Grace',
+		links: [
+			{ href: 'mailto:ada@example.test', label: 'Email' },
+			{ href: 'tel:555', label: 'Phone' },
+			{ href: 'geo:1,2', label: 'Baltimore' },
+			{ href: 'https://example.test', label: 'Site' },
+		],
+		letter: {
+			date: '2026-08-12',
+			recipient: {
+				name: 'Pat',
+				title: 'Director',
+				organization: 'Example',
+				address: ['One Way', 'Baltimore, MD'],
+			},
+			subject: 'RE: Role',
+			greeting: 'Dear Pat,',
+			markdown:
+				'See [guide](https://guide.test) and `code`.\n\n- one\n- two\n  - nested\n\n```\nblock\n```',
+			closing: 'Regards,',
+		},
+	} as unknown as CoverLetterDocument
+	const markdown = `# Ada\n\nLeader | Baltimore\n\n[ada@example.test](mailto:ada@example.test)\n[Phone](tel:555)\n[Baltimore](geo:1,2)\n[example.test](https://example.test)\n\nAugust 12, 2026\n\nPat\nDirector\nExample\nOne Way\nBaltimore, MD\n\n**RE: Role**\n\nDear Pat,\n\nSee [guide](https://guide.test) and \`code\`.\n\n- one\n- two\n  - nested\n\n\`\`\`\nblock\n\`\`\`\n\nRegards,\nGrace`
+	assert.equal(serializeCoverLetterMarkdown(document), markdown)
+	assert.equal(
+		serializeCoverLetterText(document),
+		`Ada\n\nLeader | Baltimore\n\nada@example.test\nPhone\nBaltimore\nexample.test (https://example.test)\n\nAugust 12, 2026\n\nPat\nDirector\nExample\nOne Way\nBaltimore, MD\n\nRE: Role\n\nDear Pat,\n\nSee guide (https://guide.test) and code.\n\n- one\n- two\n  - nested\n\nblock\n\nRegards,\nGrace`,
+	)
+	assert.match(serializeCoverLetterMarkdown({ ...document, senderName: 'Ada' }), /Regards,\nAda$/)
+	assert.match(
+		serializeCoverLetterMarkdown({ ...document, senderName: document.profile.name }),
+		/Regards,\nAda$/,
+	)
+})
+
+test('document-specific text wrappers use the canonical serializers', async () => {
+	const resume = createResumeDocument(await content(), config)
+	assert.equal(serializeResumeText(resume), serializeText(serializeResumeMarkdown(resume)))
+	const root = await fs.mkdtemp(path.join('/tmp', 'wrapper-letter-'))
+	try {
+		await fs.mkdir(path.join(root, 'cover-letter'))
+		await fs.writeFile(
+			path.join(root, 'cover-letter', 'letter.md'),
+			`---\ntitle: Letter\narchetype: cover-letter\npublished: true\ndate: 2026-08-12\nrecipient:\n  organization: Example\ngreeting: Hello\n---\n\nBody.`,
+		)
+		const letter = createCoverLetterDocument(
+			await resolveMarkdownLayers([
+				await loadMarkdown(path.join(cwd, 'content'), 'content'),
+				await loadMarkdown(root, '.'),
+			]),
+			config,
+		)
+		assert.ok(letter)
+		assert.equal(
+			serializeCoverLetterText(letter),
+			serializeText(serializeCoverLetterMarkdown(letter)),
+		)
+	} finally {
+		await fs.rm(root, { recursive: true, force: true })
+	}
+})
+
+test('cover letter document serializes headers, recipient, subject, body, and sender', async t => {
+	const root = await fs.mkdtemp(path.join('/tmp', 'document-letter-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	await fs.mkdir(path.join(root, 'cover-letter'))
+	await fs.writeFile(
+		path.join(root, 'cover-letter', 'letter.md'),
+		`---\ntitle: Letter\narchetype: cover-letter\npublished: true\ndate: 2026-08-12\nrecipient:\n  name: Pat Person\n  title: Hiring Manager\n  organization: Example\n  address: [One Way, Baltimore]\nsubject: 'RE: Role'\ngreeting: 'Dear Pat,'\nclosing: 'Regards,'\nsender:\n  name: Sender\n---\n\nHello **there**.`,
+	)
+	const layered = await resolveMarkdownLayers([
+		await loadMarkdown(path.join(cwd, 'content'), 'content'),
+		await loadMarkdown(root, '.'),
+	])
+	const document = createCoverLetterDocument(layered, config)
+	assert.ok(document)
+	const markdown = serializeCoverLetterMarkdown(document)
+	assert.match(
+		markdown,
+		/August 12, 2026[\s\S]*Pat Person[\s\S]*\*\*RE: Role\*\*[\s\S]*Hello \*\*there\*\*[\s\S]*Regards,[\s\S]*Sender/,
+	)
+})
+
+test('layered parser content applies private contact and ordered resume overrides', async t => {
+	const root = await fs.mkdtemp(path.join('/tmp', 'layered-document-'))
+	t.after(() => fs.rm(root, { recursive: true, force: true }))
+	const base = path.join(root, 'base')
+	const overlay = path.join(root, 'overlay')
+	await Promise.all([
+		fs.mkdir(path.join(base, 'resume'), { recursive: true }),
+		fs.mkdir(path.join(base, 'contact'), { recursive: true }),
+		fs.mkdir(path.join(base, 'experience'), { recursive: true }),
+		fs.mkdir(path.join(base, 'organizations'), { recursive: true }),
+		fs.mkdir(path.join(overlay, 'resume'), { recursive: true }),
+		fs.mkdir(path.join(overlay, 'contact'), { recursive: true }),
+	])
+	await fs.writeFile(
+		path.join(base, 'resume', 'Profile.md'),
+		`---\ntitle: Profile\narchetype: resume-section\nkind: profile\npublished: true\norder: 2\nname: Name\nheadline: Public\nlocation: Here\n---\n\nPublic profile.`,
+	)
+	await fs.writeFile(
+		path.join(base, 'resume', 'Experience.md'),
+		`---\ntitle: Experience\narchetype: resume-section\nkind: experience\npublished: true\norder: 4\nlimit: 1\n---`,
+	)
+	await fs.writeFile(
+		path.join(base, 'resume', 'Remove.md'),
+		`---\ntitle: Remove\narchetype: resume-section\nkind: prose\npublished: true\norder: 3\n---\n\nRemove me.`,
+	)
+	await fs.writeFile(
+		path.join(base, 'contact', 'Email.md'),
+		`---\ntitle: Email\narchetype: link\npublished: true\nslug: email\nlabel: Email\nhref: mailto:public@example.test\nareas: [resume]\n---`,
+	)
+	await fs.writeFile(
+		path.join(base, 'organizations', 'Org.md'),
+		`---\ntitle: Org\narchetype: organization\npublished: true\nslug: org\nlabel: Org\nlocation: Here\n---`,
+	)
+	await fs.writeFile(
+		path.join(base, 'experience', 'Role.md'),
+		`---\ntitle: Role\narchetype: experience\npublished: true\norganization: org\nstartDate: 2020-01-01\nlocation: Here\ntype: fte\nrole: fte\njobTitle: Role\n---\n\nRole body.`,
+	)
+	await fs.writeFile(path.join(overlay, 'resume', 'Remove.md'), `---\npublished: false\n---`)
+	await fs.writeFile(
+		path.join(overlay, 'resume', 'Private.md'),
+		`---\ntitle: Private note\narchetype: resume-section\nkind: prose\npublished: true\norder: 3\n---\n\nPrivate prose.`,
+	)
+	await fs.writeFile(
+		path.join(overlay, 'contact', 'Phone.md'),
+		`---\ntitle: Phone\narchetype: link\npublished: true\nslug: phone\nlabel: Phone\nhref: tel:555\nareas: [resume]\n---`,
+	)
+	const publicDocument = createResumeDocument(
+		await resolveMarkdownLayers([await loadMarkdown(base, '.')]),
+		config,
+	)
+	const privateDocument = createResumeDocument(
+		await resolveMarkdownLayers([await loadMarkdown(base, '.'), await loadMarkdown(overlay, '.')]),
+		config,
+	)
+	assert.doesNotMatch(serializeResumeMarkdown(publicDocument), /Private prose|tel:555/)
+	const markdown = serializeResumeMarkdown(privateDocument)
+	assert.match(markdown, /## Private note[\s\S]*Private prose/)
+	assert.doesNotMatch(markdown, /Remove me/)
+	assert.match(markdown, /\[Phone\]\(tel:555\)/)
+	assert.equal(
+		(
+			privateDocument.sections.find(section => section.kind === 'experience') as {
+				roles: readonly unknown[]
+			}
+		).roles.length,
+		1,
+	)
+})

--- a/src/content/documents.test.ts
+++ b/src/content/documents.test.ts
@@ -62,6 +62,41 @@ test('serializers preserve Markdown tokens, normalize ASCII text, and reject uns
 	assert.throws(() => serializeText('emoji 😀'), /ASCII-normalized/)
 })
 
+test('text serializer renders inline and block HTML tokens as visible text', () => {
+	assert.equal(
+		serializeText(
+			'Platform Reliability Team (<abbr title="Platform Reliability Team">PRT</abbr>) uses <strong>nested <em>HTML</em></strong> &amp; numeric entities: &#38; and &#x26;.',
+		),
+		'Platform Reliability Team (PRT) uses nested HTML & numeric entities: & and &.',
+	)
+	assert.equal(
+		serializeText(
+			'<p><abbr>PRT</abbr> &amp; <strong>nested <em>text</em></strong></p><p>Next paragraph.</p>',
+		),
+		'PRT & nested text\n\nNext paragraph.',
+	)
+	assert.throws(() => serializeText('Malformed numeric entity: &#x110000;.'), /ASCII-normalized/)
+	assert.throws(
+		() => serializeText('Use <abbr title="A > B">PRT</abbr> &amp; &#0;.'),
+		/ASCII-normalized/,
+	)
+	assert.throws(() => serializeText('<span>&copy;</span>'), /ASCII-normalized/)
+	assert.throws(() => serializeText('&reg;'), /ASCII-normalized/)
+	assert.throws(() => serializeText('&notARealEntity;'), /ASCII-normalized/)
+	assert.equal(serializeText('&madeup; R&D;'), '&madeup; R&D;')
+	assert.equal(
+		serializeText('`&amp; &copy; &reg;`\n\n```\n&amp; &copy; &reg;\n```'),
+		'&amp; &copy; &reg;\n\n&amp; &copy; &reg;',
+	)
+	assert.equal(
+		serializeText(
+			'Visible <script type="text/plain">hidden &amp;</script><style>.hidden { color: red; }</style> text.',
+		),
+		'Visible text.',
+	)
+	assert.equal(serializeText('**Visible <script>hidden</script> text.**'), 'Visible text.')
+})
+
 test('text serializer exactly preserves visible contact and link conventions', () => {
 	assert.equal(
 		serializeText(

--- a/src/content/documents.ts
+++ b/src/content/documents.ts
@@ -1,4 +1,5 @@
 import { Lexer, type Token } from 'marked'
+import { decodeHTML } from 'entities'
 import type Config from '../config/Config'
 import type Entry from './Entry'
 import EducationEntry from './EducationEntry'
@@ -258,9 +259,7 @@ const proseTokensText = (tokens: readonly Token[]): string =>
 						})
 						.join('\n'),
 				]
-			return value.tokens
-				? [value.tokens.map(token => inlineText(token)).join('')]
-				: [value.text ?? '']
+			return [value.tokens ? inlineTokensText(value.tokens) : inlineText(token)]
 		})
 		.join('\n\n')
 		.replace(/\n{3,}/g, '\n\n')
@@ -268,15 +267,59 @@ const proseTokensText = (tokens: readonly Token[]): string =>
 
 const proseText = (markdown: string): string => proseTokensText(Lexer.lex(markdown))
 
+const isRawHtmlStart = (value: string): boolean => /^<(?:script|style)\b/i.test(value)
+const isRawHtmlEnd = (value: string): boolean => /^<\/(?:script|style)\s*>/i.test(value)
+const inlineTokensText = (tokens: readonly Token[]): string => {
+	let rawHtml = false
+	let skipLeadingWhitespace = false
+	return tokens
+		.map(token => {
+			const value = token as Token & { text?: string }
+			if (value.type === 'html' && isRawHtmlStart(value.text ?? '')) {
+				rawHtml = true
+				return ''
+			}
+			if (value.type === 'html' && rawHtml && isRawHtmlEnd(value.text ?? '')) {
+				rawHtml = false
+				skipLeadingWhitespace = true
+				return ''
+			}
+			if (rawHtml) return ''
+			const text = inlineText(token)
+			if (!skipLeadingWhitespace) return text
+			skipLeadingWhitespace = false
+			return text.replace(/^[ \t]+/, '')
+		})
+		.join('')
+}
+
+const decodeHtmlEntities = (value: string): string => decodeHTML(value)
+
+const htmlText = (value: string): string =>
+	decodeHtmlEntities(
+		value
+			.replace(/<!--[\s\S]*?-->/g, '')
+			.replace(/<(script|style)\b(?:"[^"]*"|'[^']*'|[^'">])*>[\s\S]*?<\/\1\s*>/gi, '')
+			.replace(
+				/<\/?(?:address|article|aside|blockquote|div|dl|dt|dd|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b(?:"[^"]*"|'[^']*'|[^'">])*>/gi,
+				'\n',
+			)
+			.replace(/<br\b(?:"[^"]*"|'[^']*'|[^'">])*>/gi, '\n')
+			.replace(/<(?:"[^"]*"|'[^']*'|[^'">])*>/g, ''),
+	).replace(/[ \t]*\n[ \t]*/g, '\n')
+
 const inlineText = (token: Token): string => {
 	const value = token as Token & { text?: string; href?: string; tokens?: Token[] }
 	if (value.type === 'link') {
-		const label = value.tokens?.map(inlineText).join('') ?? value.text ?? ''
+		const label = value.tokens ? inlineTokensText(value.tokens) : (value.text ?? '')
 		if (value.href?.startsWith('mailto:')) return value.href.slice('mailto:'.length)
 		if (value.href?.startsWith('tel:') || value.href?.startsWith('geo:')) return label
 		return label === value.href ? label : `${label} (${value.href})`
 	}
-	return value.tokens?.map(inlineText).join('') ?? value.text ?? ''
+	if (value.type === 'html') return htmlText(value.text ?? '')
+	if (value.type === 'text')
+		return value.tokens ? inlineTokensText(value.tokens) : decodeHtmlEntities(value.text ?? '')
+	return value.tokens ? inlineTokensText(value.tokens) : (value.text ?? '')
 }
 
 const ascii = (value: string): string => {

--- a/src/content/documents.ts
+++ b/src/content/documents.ts
@@ -1,0 +1,382 @@
+import { Lexer, type Token } from 'marked'
+import type Config from '../config/Config'
+import type Entry from './Entry'
+import EducationEntry from './EducationEntry'
+import ExperienceEntry from './ExperienceEntry'
+import OrganizationEntry from './OrganizationEntry'
+import { getCoverLetter, type CoverLetter } from './coverLetter'
+import {
+	type ResumeEducationSection,
+	type ResumeExperienceSection,
+	type ResumeProfile,
+	type ResumeSection,
+} from './resume'
+import type { ContentLink } from './links'
+import { formatResumeLinkLabel } from '../components/resume/format'
+
+export interface ResumeDocument {
+	readonly profile: ResumeProfile
+	readonly links: readonly ContentLink[]
+	readonly sections: readonly ResolvedResumeSection[]
+}
+
+export type ResolvedResumeSection =
+	| Exclude<ResumeSection, ResumeExperienceSection | ResumeEducationSection>
+	| (ResumeExperienceSection & { readonly roles: readonly ResumeRole[] })
+	| (ResumeEducationSection & { readonly education: readonly EducationEntry[] })
+
+export interface ResumeRole {
+	readonly experience: ExperienceEntry
+	readonly organization: OrganizationEntry
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value)
+const isString = (value: unknown): value is string => typeof value === 'string'
+const educationDate = (entry: EducationEntry): number =>
+	(entry.endDate ?? entry.startDate ?? new Date(0)).valueOf()
+const linkRank = (link: ContentLink): number => (link.href.startsWith('mailto:') ? 0 : 1)
+
+export const createResumeDocument = (content: readonly Entry[], config: Config): ResumeDocument => {
+	const organizations = new Map(
+		content
+			.filter(entry => entry.category === 'organizations')
+			.map(entry => [
+				entry.data.slug as string,
+				new OrganizationEntry(entry.category, entry.data, entry.html, entry.markdown, entry.name),
+			]),
+	)
+	const sections = content
+		.filter(entry => entry.category === 'resume' && entry.data.archetype === 'resume-section')
+		.flatMap<ResumeSection>(entry => {
+			const { data } = entry
+			if (!isString(data.title) || typeof data.order !== 'number' || !isString(data.kind)) return []
+			const base = {
+				entryName: entry.name,
+				html: entry.html,
+				markdown: entry.markdown,
+				order: data.order,
+				title: data.title,
+			}
+			switch (data.kind) {
+				case 'profile':
+					return isString(data.name) && isString(data.headline) && isString(data.location)
+						? [
+								{
+									...base,
+									headline: data.headline,
+									kind: data.kind,
+									location: data.location,
+									name: data.name,
+								},
+							]
+						: []
+				case 'metrics':
+					return [
+						{
+							...base,
+							kind: data.kind,
+							metrics: Array.isArray(data.metrics)
+								? data.metrics.flatMap(metric =>
+										isRecord(metric) && isString(metric.value) && isString(metric.label)
+											? [
+													{
+														detail: isString(metric.detail) ? metric.detail : undefined,
+														label: metric.label,
+														value: metric.value,
+													},
+												]
+											: [],
+									)
+								: [],
+						},
+					]
+				case 'skills':
+					return [
+						{
+							...base,
+							kind: data.kind,
+							groups: Array.isArray(data.groups)
+								? data.groups.flatMap(group =>
+										isRecord(group) &&
+										isString(group.label) &&
+										Array.isArray(group.items) &&
+										group.items.every(isString)
+											? [{ items: group.items, label: group.label }]
+											: [],
+									)
+								: [],
+						},
+					]
+				case 'prose':
+					return [{ ...base, kind: data.kind }]
+				case 'experience':
+					return [
+						{
+							...base,
+							kind: data.kind,
+							limit: typeof data.limit === 'number' ? data.limit : undefined,
+						},
+					]
+				case 'education':
+					return [{ ...base, kind: data.kind }]
+				default:
+					return []
+			}
+		})
+		.sort((a, b) => a.order - b.order || a.entryName.localeCompare(b.entryName))
+	const profile = sections.find(
+		(section): section is ResumeProfile => section.kind === 'profile',
+	) ?? {
+		entryName: 'resume/Profile.md',
+		headline: '',
+		html: '',
+		markdown: '',
+		kind: 'profile' as const,
+		location: '',
+		name: config.siteTitle,
+		order: 0,
+		title: 'Profile',
+	}
+	const links = content
+		.filter(
+			entry =>
+				(entry.category === 'contact' || entry.category === 'social') &&
+				entry.data.archetype === 'link' &&
+				(Array.isArray(entry.data.areas) ? entry.data.areas : [entry.data.areas]).includes(
+					'resume',
+				),
+		)
+		.flatMap<ContentLink>(entry =>
+			isString(entry.data.href) && isString(entry.data.label) && isString(entry.data.slug)
+				? [
+						{
+							category: entry.category,
+							href: entry.data.href,
+							label: entry.data.label,
+							name: entry.name,
+							order:
+								typeof entry.data.order === 'number' ? entry.data.order : Number.MAX_SAFE_INTEGER,
+							slug: entry.data.slug,
+							title: isString(entry.data.title) ? entry.data.title : entry.name,
+						},
+					]
+				: [],
+		)
+		.sort((a, b) => linkRank(a) - linkRank(b) || a.order - b.order || a.name.localeCompare(b.name))
+	const roles = content
+		.filter(entry => entry.category === 'experience')
+		.map(
+			entry =>
+				new ExperienceEntry(entry.category, entry.data, entry.html, entry.markdown, entry.name),
+		)
+		.filter(entry => entry.resumeInclude)
+		.flatMap(experience => {
+			const organization = organizations.get(experience.organization)
+			return organization ? [{ experience, organization }] : []
+		})
+		.sort((a, b) => b.experience.startDate.valueOf() - a.experience.startDate.valueOf())
+	const education = content
+		.filter(entry => entry.category === 'education')
+		.map(
+			entry =>
+				new EducationEntry(
+					entry.category,
+					entry.data,
+					entry.html,
+					entry.markdown,
+					entry.name,
+					organizations.get(entry.data.organization as string),
+				),
+		)
+		.filter(entry => entry.resumeInclude)
+		.sort((a, b) => educationDate(b) - educationDate(a))
+	return {
+		profile,
+		links,
+		sections: sections.map(section =>
+			section.kind === 'experience'
+				? { ...section, roles: section.limit === undefined ? roles : roles.slice(0, section.limit) }
+				: section.kind === 'education'
+					? { ...section, education }
+					: section,
+		),
+	}
+}
+
+export interface CoverLetterDocument {
+	readonly letter: CoverLetter
+	readonly profile: ResumeProfile
+	readonly links: readonly ContentLink[]
+	readonly senderName: string
+}
+export const createCoverLetterDocument = (
+	content: readonly Entry[],
+	config: Config,
+): CoverLetterDocument | undefined => {
+	const letter = getCoverLetter([...content])
+	if (!letter) return undefined
+	const resume = createResumeDocument(content, config)
+	return {
+		letter,
+		profile: resume.profile,
+		links: resume.links,
+		senderName: letter.sender?.name ?? resume.profile.name,
+	}
+}
+
+export const formatResumeDate = (date: Date): string =>
+	new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }).format(
+		date,
+	)
+export const formatCoverLetterDate = (value: Date | string): string =>
+	new Intl.DateTimeFormat('en-US', { dateStyle: 'long', timeZone: 'UTC' }).format(
+		value instanceof Date ? value : new Date(value.length === 10 ? `${value}T00:00:00Z` : value),
+	)
+export const formatEducation = (entry: EducationEntry): string =>
+	entry.degree ? `${entry.degree}, ${entry.program}` : entry.program
+
+const proseTokensText = (tokens: readonly Token[]): string =>
+	tokens
+		.flatMap((token: Token) => {
+			const value = token as Token & { text?: string; tokens?: Token[]; items?: Token[] }
+			if (value.type === 'space' || value.type === 'def') return []
+			if (value.type === 'list' && value.items)
+				return [
+					value.items
+						.map(item => {
+							const itemValue = item as unknown as { text?: string; tokens?: Token[] }
+							const lines = proseTokensText(itemValue.tokens ?? Lexer.lex(itemValue.text ?? ''))
+								.split('\n')
+								.filter(
+									(line, index, values) => line !== '' || !values[index + 1]?.startsWith('- '),
+								)
+							return [
+								`- ${lines[0] ?? ''}`,
+								...lines.slice(1).map(line => (line === '' ? line : `  ${line}`)),
+							].join('\n')
+						})
+						.join('\n'),
+				]
+			return value.tokens
+				? [value.tokens.map(token => inlineText(token)).join('')]
+				: [value.text ?? '']
+		})
+		.join('\n\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+
+const proseText = (markdown: string): string => proseTokensText(Lexer.lex(markdown))
+
+const inlineText = (token: Token): string => {
+	const value = token as Token & { text?: string; href?: string; tokens?: Token[] }
+	if (value.type === 'link') {
+		const label = value.tokens?.map(inlineText).join('') ?? value.text ?? ''
+		if (value.href?.startsWith('mailto:')) return value.href.slice('mailto:'.length)
+		if (value.href?.startsWith('tel:') || value.href?.startsWith('geo:')) return label
+		return label === value.href ? label : `${label} (${value.href})`
+	}
+	return value.tokens?.map(inlineText).join('') ?? value.text ?? ''
+}
+
+const ascii = (value: string): string => {
+	const normalized = value
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.replace(/[–—]/g, '-')
+		.replace(/[‘’]/g, "'")
+		.replace(/[“”]/g, '"')
+		.replace(/…/g, '...')
+	if (Array.from(normalized).some(character => (character.codePointAt(0) ?? 0) > 127))
+		throw new Error('Text output contains characters that cannot be ASCII-normalized.')
+	return normalized
+}
+
+export const serializeResumeMarkdown = (document: ResumeDocument): string => {
+	const lines = [
+		`# ${document.profile.name}`,
+		'',
+		`${document.profile.headline} | ${document.profile.location}`,
+		'',
+		...document.links.map(
+			link => `[${formatResumeLinkLabel(link.href, link.label)}](${link.href})`,
+		),
+		'',
+	]
+	for (const section of document.sections) {
+		lines.push(`## ${section.title}`, '')
+		if (section.kind === 'profile') lines.push(section.markdown.trim())
+		else if (section.kind === 'metrics')
+			lines.push(
+				...section.metrics.flatMap(metric => [
+					`- **${metric.value} — ${metric.label}**${metric.detail ? `: ${metric.detail}` : ''}`,
+				]),
+			)
+		else if (section.kind === 'skills')
+			lines.push(...section.groups.map(group => `- **${group.label}:** ${group.items.join(', ')}`))
+		else if (section.kind === 'prose') lines.push(section.markdown.trim())
+		else if (section.kind === 'experience')
+			for (const { experience, organization } of section.roles) {
+				lines.push(
+					`### ${experience.jobTitle}`,
+					'',
+					`${organization.label} | ${formatResumeDate(experience.startDate)} - ${experience.endDate ? formatResumeDate(experience.endDate) : 'Present'} | ${experience.location}`,
+					'',
+				)
+				if (experience.resumeSummary || experience.resumeHighlights.length) {
+					if (experience.resumeSummary) lines.push(experience.resumeSummary, '')
+					lines.push(...experience.resumeHighlights.map(value => `- ${value}`))
+				} else lines.push(experience.markdown.trim())
+			}
+		else if (section.kind === 'education')
+			for (const entry of section.education) {
+				lines.push(
+					`### ${formatEducation(entry)}`,
+					'',
+					`${entry.institution}${entry.endDate ? ` | ${entry.endDate.getUTCFullYear()}` : ''}`,
+				)
+				if (entry.honors.length) lines.push('', `- ${entry.honors.join(', ')}`)
+			}
+		lines.push('')
+	}
+	return lines.join('\n')
+}
+
+export const serializeCoverLetterMarkdown = ({
+	letter,
+	profile,
+	links,
+	senderName,
+}: CoverLetterDocument): string =>
+	[
+		`# ${profile.name}`,
+		'',
+		`${profile.headline} | ${profile.location}`,
+		'',
+		...links.map(link => `[${formatResumeLinkLabel(link.href, link.label)}](${link.href})`),
+		'',
+		formatCoverLetterDate(letter.date),
+		'',
+		...[
+			letter.recipient.name,
+			letter.recipient.title,
+			letter.recipient.organization,
+			...(letter.recipient.address ?? []),
+		].filter(Boolean),
+		'',
+		...(letter.subject ? [`**${letter.subject}**`, ''] : []),
+		letter.greeting,
+		'',
+		letter.markdown.trim(),
+		'',
+		letter.closing,
+		senderName,
+	]
+		.filter((line, index, values) => line !== '' || index === 0 || values[index - 1] !== '')
+		.join('\n')
+
+export const serializeText = (markdown: string): string => ascii(proseText(markdown))
+export const serializeResumeText = (document: ResumeDocument): string =>
+	serializeText(serializeResumeMarkdown(document))
+export const serializeCoverLetterText = (document: CoverLetterDocument): string =>
+	serializeText(serializeCoverLetterMarkdown(document))

--- a/src/content/documents.ts
+++ b/src/content/documents.ts
@@ -240,20 +240,30 @@ export const formatEducation = (entry: EducationEntry): string =>
 const proseTokensText = (tokens: readonly Token[]): string =>
 	tokens
 		.flatMap((token: Token) => {
-			const value = token as Token & { text?: string; tokens?: Token[]; items?: Token[] }
+			const value = token as Token & {
+				text?: string
+				tokens?: Token[]
+				items?: Token[]
+				ordered?: boolean
+				start?: number | ''
+			}
 			if (value.type === 'space' || value.type === 'def') return []
 			if (value.type === 'list' && value.items)
 				return [
 					value.items
-						.map(item => {
+						.map((item, index) => {
 							const itemValue = item as unknown as { text?: string; tokens?: Token[] }
 							const lines = proseTokensText(itemValue.tokens ?? Lexer.lex(itemValue.text ?? ''))
 								.split('\n')
 								.filter(
-									(line, index, values) => line !== '' || !values[index + 1]?.startsWith('- '),
+									(line, lineIndex, values) =>
+										line !== '' || !/^(?:-|\d+\.) /.test(values[lineIndex + 1] ?? ''),
 								)
+							const marker = value.ordered
+								? `${(typeof value.start === 'number' ? value.start : 1) + index}.`
+								: '-'
 							return [
-								`- ${lines[0] ?? ''}`,
+								`${marker} ${lines[0] ?? ''}`,
 								...lines.slice(1).map(line => (line === '' ? line : `  ${line}`)),
 							].join('\n')
 						})

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -1,13 +1,7 @@
-import { useConfigValue } from '../config/ConfigContext'
-import { useContent } from './ContentContext'
-import EducationEntry from './EducationEntry'
-import ExperienceEntry from './ExperienceEntry'
-import { type ContentLink, useLinks } from './links'
-import OrganizationEntry from './OrganizationEntry'
-
 interface ResumeSectionBase {
 	readonly entryName: string
 	readonly html: string
+	readonly markdown: string
 	readonly order: number
 	readonly title: string
 }
@@ -18,41 +12,33 @@ export interface ResumeProfile extends ResumeSectionBase {
 	readonly location: string
 	readonly name: string
 }
-
 export interface ResumeMetric {
 	readonly detail?: string
 	readonly label: string
 	readonly value: string
 }
-
 export interface ResumeMetricsSection extends ResumeSectionBase {
 	readonly kind: 'metrics'
 	readonly metrics: readonly ResumeMetric[]
 }
-
 export interface ResumeSkillGroup {
 	readonly items: readonly string[]
 	readonly label: string
 }
-
 export interface ResumeSkillsSection extends ResumeSectionBase {
 	readonly groups: readonly ResumeSkillGroup[]
 	readonly kind: 'skills'
 }
-
 export interface ResumeProseSection extends ResumeSectionBase {
 	readonly kind: 'prose'
 }
-
 export interface ResumeExperienceSection extends ResumeSectionBase {
 	readonly kind: 'experience'
 	readonly limit?: number
 }
-
 export interface ResumeEducationSection extends ResumeSectionBase {
 	readonly kind: 'education'
 }
-
 export type ResumeSection =
 	| ResumeProfile
 	| ResumeMetricsSection
@@ -60,181 +46,3 @@ export type ResumeSection =
 	| ResumeProseSection
 	| ResumeExperienceSection
 	| ResumeEducationSection
-
-export interface ResumeRole {
-	readonly experience: ExperienceEntry
-	readonly organization: OrganizationEntry
-}
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === 'object' && value !== null && !Array.isArray(value)
-
-const isString = (value: unknown): value is string => typeof value === 'string'
-
-const getComparableDate = (entry: EducationEntry): number =>
-	(entry.endDate ?? entry.startDate ?? new Date(0)).valueOf()
-
-const getResumeLinkRank = (link: ContentLink): number => (link.href.startsWith('mailto:') ? 0 : 1)
-
-const getResumeSections = (content: ReturnType<typeof useContent>): ResumeSection[] => {
-	const sections = content
-		.filter(entry => entry.category === 'resume' && entry.data.archetype === 'resume-section')
-		.flatMap<ResumeSection>((entry): ResumeSection[] => {
-			const { data } = entry
-			if (!isString(data.title) || typeof data.order !== 'number' || !isString(data.kind)) {
-				return []
-			}
-			const base = { entryName: entry.name, html: entry.html, order: data.order, title: data.title }
-
-			switch (data.kind) {
-				case 'profile':
-					return isString(data.name) && isString(data.headline) && isString(data.location)
-						? [
-								{
-									...base,
-									headline: data.headline,
-									kind: data.kind,
-									location: data.location,
-									name: data.name,
-								},
-							]
-						: []
-				case 'metrics': {
-					const metrics = Array.isArray(data.metrics)
-						? data.metrics.flatMap(metric =>
-								isRecord(metric) && isString(metric.value) && isString(metric.label)
-									? [
-											{
-												detail: isString(metric.detail) ? metric.detail : undefined,
-												label: metric.label,
-												value: metric.value,
-											},
-										]
-									: [],
-							)
-						: []
-					return [{ ...base, kind: data.kind, metrics }]
-				}
-				case 'skills': {
-					const groups = Array.isArray(data.groups)
-						? data.groups.flatMap(group =>
-								isRecord(group) &&
-								isString(group.label) &&
-								Array.isArray(group.items) &&
-								group.items.every(isString)
-									? [{ items: group.items, label: group.label }]
-									: [],
-							)
-						: []
-					return [{ ...base, groups, kind: data.kind }]
-				}
-				case 'prose':
-					return [{ ...base, kind: data.kind }]
-				case 'experience':
-					return [
-						{
-							...base,
-							kind: data.kind,
-							limit: typeof data.limit === 'number' ? data.limit : undefined,
-						},
-					]
-				case 'education':
-					return [{ ...base, kind: data.kind }]
-				default:
-					return []
-			}
-		})
-
-	return sections.sort(
-		(sectionA, sectionB) =>
-			sectionA.order - sectionB.order || sectionA.entryName.localeCompare(sectionB.entryName),
-	)
-}
-
-export const useResumeSections = (): ResumeSection[] => getResumeSections(useContent())
-
-export const useResumeProfile = (): ResumeProfile => {
-	const siteTitle = useConfigValue('siteTitle')
-	const profile = useResumeSections().find(
-		(section): section is ResumeProfile => section.kind === 'profile',
-	)
-
-	return (
-		profile ?? {
-			entryName: 'resume/Profile.md',
-			headline: '',
-			html: '',
-			kind: 'profile',
-			location: '',
-			name: siteTitle,
-			order: 0,
-			title: 'Profile',
-		}
-	)
-}
-
-export const useResumeExperience = (limit?: number): ResumeRole[] => {
-	const content = useContent()
-	const organizations = new Map(
-		content
-			.filter(entry => entry.category === 'organizations')
-			.map(entry => [
-				entry.data.slug as string,
-				new OrganizationEntry(entry.category, entry.data, entry.html, entry.markdown, entry.name),
-			]),
-	)
-
-	const roles = content
-		.filter(entry => entry.category === 'experience')
-		.map(
-			entry =>
-				new ExperienceEntry(entry.category, entry.data, entry.html, entry.markdown, entry.name),
-		)
-		.filter(experience => experience.resumeInclude)
-		.map(experience => {
-			const organization = organizations.get(experience.organization)
-			return organization ? { experience, organization } : null
-		})
-		.filter((role): role is ResumeRole => role !== null)
-		.sort(
-			(roleA, roleB) => roleB.experience.startDate.valueOf() - roleA.experience.startDate.valueOf(),
-		)
-
-	return limit === undefined ? roles : roles.slice(0, limit)
-}
-
-export const useResumeEducation = (): EducationEntry[] => {
-	const content = useContent()
-	const organizations = new Map(
-		content
-			.filter(entry => entry.category === 'organizations')
-			.map(entry => [
-				entry.data.slug as string,
-				new OrganizationEntry(entry.category, entry.data, entry.html, entry.markdown, entry.name),
-			]),
-	)
-
-	return content
-		.filter(entry => entry.category === 'education')
-		.map(
-			entry =>
-				new EducationEntry(
-					entry.category,
-					entry.data,
-					entry.html,
-					entry.markdown,
-					entry.name,
-					organizations.get(entry.data.organization as string),
-				),
-		)
-		.filter(entry => entry.resumeInclude)
-		.sort((entryA, entryB) => getComparableDate(entryB) - getComparableDate(entryA))
-}
-
-export const useResumeLinks = (): ContentLink[] =>
-	[...useLinks({ area: 'resume', category: ['contact', 'social'] })].sort(
-		(linkA, linkB) =>
-			getResumeLinkRank(linkA) - getResumeLinkRank(linkB) ||
-			linkA.order - linkB.order ||
-			linkA.name.localeCompare(linkB.name),
-	)

--- a/src/pages/CoverLetter.tsx
+++ b/src/pages/CoverLetter.tsx
@@ -1,19 +1,14 @@
 import DocumentActions, { DocumentPrintScript } from '../components/document/DocumentActions'
 import ResumeHeader from '../components/resume/ResumeHeader'
-import { useCoverLetter } from '../content/coverLetter'
-import { useResumeProfile } from '../content/resume'
-
-const formatDate = (value: Date | string) => {
-	const date =
-		value instanceof Date ? value : new Date(value.length === 10 ? `${value}T00:00:00Z` : value)
-	return new Intl.DateTimeFormat('en-US', { dateStyle: 'long', timeZone: 'UTC' }).format(date)
-}
+import { useContent } from '../content/ContentContext'
+import { useConfig } from '../config/ConfigContext'
+import { createCoverLetterDocument, formatCoverLetterDate } from '../content/documents'
 
 const CoverLetter = () => {
-	const letter = useCoverLetter()
-	const profile = useResumeProfile()
-	if (!letter)
+	const document = createCoverLetterDocument(useContent(), useConfig())
+	if (!document)
 		throw new Error('A cover letter was requested but no published cover letter was found.')
+	const { letter, profile } = document
 	return (
 		<>
 			<main className="cover-letter-page" aria-labelledby="resume-title">
@@ -24,8 +19,8 @@ const CoverLetter = () => {
 						eventPrefix="cover-letter"
 					/>
 					<article className="cover-letter-sheet">
-						<ResumeHeader />
-						<p className="cover-letter-date">{formatDate(letter.date)}</p>
+						<ResumeHeader document={{ ...document, sections: [] }} />
+						<p className="cover-letter-date">{formatCoverLetterDate(letter.date)}</p>
 						<address className="cover-letter-recipient">
 							{letter.recipient.name ? <div>{letter.recipient.name}</div> : null}
 							{letter.recipient.title ? <div>{letter.recipient.title}</div> : null}

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -3,16 +3,20 @@ import ResumeHeader from '../components/resume/ResumeHeader'
 import ResumePrintScript from '../components/resume/ResumePrintScript'
 import ResumeSections from '../components/resume/ResumeSections'
 import SiteLegal from '../components/site/SiteLegal'
+import { useContent } from '../content/ContentContext'
+import { useConfig } from '../config/ConfigContext'
+import { createResumeDocument } from '../content/documents'
 
 const Resume = () => {
+	const document = createResumeDocument(useContent(), useConfig())
 	return (
 		<>
 			<main className="resume-page" aria-labelledby="resume-title">
 				<div className="resume-document">
 					<ResumeActions />
 					<article className="resume-sheet">
-						<ResumeHeader />
-						<ResumeSections />
+						<ResumeHeader document={document} />
+						<ResumeSections document={document} />
 					</article>
 					<SiteLegal />
 				</div>


### PR DESCRIPTION
## Summary

- add format-neutral resume and cover-letter document assembly shared by HTML, Markdown, and plain-text rendering
- generate `resume.html`, `resume.pdf`, `resume.md`, and `resume.txt` for public builds
- generate all four resume artifacts plus all four cover-letter artifacts for private application packages when a letter exists
- replace the legacy `pdf` page flag with a validated `formats` contract while preserving existing HTML/PDF output, metadata, sitemap, and privacy behavior
- document the expanded output inventory and add focused configuration, document-model, serializer, layering, and build integration coverage

Issue #7 originally scoped the feature to resumes; this PR includes the approved cover-letter scope expansion.

## Validation

- `npm run check`
- public build and artifact inspection
- representative `build:resume outside-engineering-manager --contentDir variants/content-sensitive`
- representative `build:application outside-engineering-manager --contentDir variants/content-sensitive`
- timestamp-normalized HTML comparisons against pre-change public resume, private resume, and cover-letter baselines
- byte-for-byte PDF comparisons and rendered-page inspection for the same three documents
- independent high-reasoning implementation review, with all actionable findings resolved

Closes #7